### PR TITLE
FLAG-27: Add ability to deploy Tags, Priorities and Flags via metadatata-deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ nb-configuration.xml
 
 ### Linux ###
 .*
+!.travis.yml
 !.gitignore
 !.gitattributes
 !.tx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+ - oraclejdk8

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -37,6 +37,16 @@
 			<artifactId>openmrs-test</artifactId>
 			<type>pom</type>
 		</dependency>
+
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>metadatadeploy-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>metadatasharing-api</artifactId>
+		</dependency>
 		
 		<!--  include groovy, but mark as provided since it is included with openmrs-core v1.10+-->
 		<dependency>

--- a/api/src/main/java/org/openmrs/module/patientflags/api/FlagService.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/FlagService.java
@@ -90,7 +90,6 @@ public interface FlagService extends OpenmrsService {
 	@Transactional(readOnly = true)
 	public List<Flag> generateFlagsForPatient(Patient patient, Set<Role> roles, String displayPointName);
 	
-	
 	/**
 	 * Generates a list of all Patients that match the criteria of the specified Flag
 	 * 
@@ -104,7 +103,7 @@ public interface FlagService extends OpenmrsService {
 	/**
 	 * Generate a map of all Patients that match the criteria of the specific Flags
 	 * 
-	 * @param flags
+	 * @param flags The flags for which patients are to be retrieved
 	 * @return a map of Patients and there corresponding flags
 	 */
 	@Transactional(readOnly = true)
@@ -133,12 +132,32 @@ public interface FlagService extends OpenmrsService {
 	/**
 	 * Retrieve a specific Flag based on its flagId
 	 * 
-	 * @param flagId
+	 * @param flagId The ID of the flag  to retrieve
 	 * @return the flag which matches the specific ID
 	 */
 	@Transactional(readOnly = true)
 	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
 	public Flag getFlag(Integer flagId);
+
+	/**
+	 * Retrieve a specific Flag based on its uuid
+	 *
+	 * @param uuid The uuid of the flag  to retrieve
+	 * @return the flag which matches the specific uuid
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Flag getFlagByUuid(String uuid);
+
+	/**
+	 * Retrieve a specific Flag based on its name
+	 *
+	 * @param name The name of the flag  to retrieve
+	 * @return the flag which matches the specific name
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Flag getFlagByName(String name);
 	
 	/**
 	 * Adds or updates a specific flag in the database
@@ -155,6 +174,15 @@ public interface FlagService extends OpenmrsService {
 	 */
 	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
 	public void purgeFlag(Integer flagId);
+
+	/**
+	 * Retires a specific flag
+	 *
+	 * @param flag the flag to retire
+	 * @param reason The reason for retiring the flag
+	 */
+	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
+	public void retireFlag(Flag flag, String reason);
 	
 	/**
 	 * Generates a list of all Patient Flag Tags
@@ -168,12 +196,32 @@ public interface FlagService extends OpenmrsService {
 	/**
 	 * Retrieve a specific Tag based on its tagId
 	 * 
-	 * @param tagId
+	 * @param tagId The ID of the tag  to retrieve
 	 * @return the Tag which matches the specific ID
 	 */
 	@Transactional(readOnly = true)
 	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
 	public Tag getTag(Integer tagId);
+
+	/**
+	 * Retrieve a specific Tag based on its uuid
+	 *
+	 * @param uuid The uuid of the tag  to retrieve
+	 * @return the Tag which matches the specific uuid
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Tag getTagByUuid(String uuid);
+
+	/**
+	 * Retrieve a specific Tag based on its name
+	 *
+	 * @param name The name of the tag  to retrieve
+	 * @return the Tag which matches the specific name
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Tag getTagByName(String name);
 	
 	/**
 	 * Retrieve a specific Tag based on its name string
@@ -181,7 +229,6 @@ public interface FlagService extends OpenmrsService {
 	 * @param name then name of tag (case-insensitive) to retrieve
 	 * @return the Tag which matches the specific name
 	 */
-	// TODO add functionality so as not to allow two flags with the same name
 	@Transactional(readOnly = true)
 	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
 	public Tag getTag(String name);
@@ -201,6 +248,15 @@ public interface FlagService extends OpenmrsService {
 	 */
 	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
 	public void purgeTag(Integer tagId);
+
+	/**
+	 * Retires a specific Tag
+	 *
+	 * @param tag The Tag to be retired
+	 * @param reason The reason for retiring the flag
+	 */
+	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
+	public void retireTag(Tag tag, String reason);
 	
 	/**
 	 * Service methods that operate on Priorities
@@ -218,12 +274,32 @@ public interface FlagService extends OpenmrsService {
 	/**
 	 * Retrieve a specific Priority based on its priorityId
 	 * 
-	 * @param tagId
-	 * @return the Tag which matches the specific ID
+	 * @param priorityId The priorityId for the priority to retrieve
+	 * @return the Priority which matches the specific ID
 	 */
 	@Transactional(readOnly = true)
 	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
 	public Priority getPriority(Integer priorityId);
+
+	/**
+	 * Retrieve a specific Priority based on its uuid
+	 *
+	 * @param uuid The uuid of the priority  to retrieve
+	 * @return the Priority which matches the specific uuid
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Priority getPriorityByUuid(String uuid);
+
+	/**
+	 * Retrieve a specific Priority based on its name
+	 *
+	 * @param name The name of the priority  to retrieve
+	 * @return the Priority which matches the specified name
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public Priority getPriorityByName(String name);
 	
 	/**
 	 * Adds or updates a specific priority in the database
@@ -240,6 +316,15 @@ public interface FlagService extends OpenmrsService {
 	 */
 	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
 	public void purgePriority(Integer priorityId);
+
+	/**
+	 * Removes a specific priority from the database
+	 *
+	 * @param priority the Priority to retire
+	 * @param reason The reason for retiring the priority
+	 */
+	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
+	public void retirePriority(Priority priority, String reason);
 	
 	/**
 	 * Generates a list of all DisplayPoints
@@ -259,6 +344,16 @@ public interface FlagService extends OpenmrsService {
 	@Transactional(readOnly = true)
 	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
 	public DisplayPoint getDisplayPoint(Integer displayPointId);
+
+	/**
+	 * Retrieve a specific DisplayPoint based on its uuid
+	 *
+	 * @param uuid The uuid of the DisplayPoint to retrieve
+	 * @return the DisplayPoint which matches the specific uuid
+	 */
+	@Transactional(readOnly = true)
+	@Authorized(value = { "Manage Flags", "Test Flags" }, requireAll = false)
+	public DisplayPoint getDisplayPointByUuid(String uuid);
 	
 	/**
 	 * Retrieve a specific DisplayPoint based on its name string
@@ -273,7 +368,7 @@ public interface FlagService extends OpenmrsService {
 	/**
 	 * Adds or updates a specific DisplayPoint in the database
 	 * 
-	 * @param tag the DisplayPoint to add or update
+	 * @param displayPoint the DisplayPoint to add or update
 	 */
 	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
 	public void saveDisplayPoint(DisplayPoint displayPoint);
@@ -284,7 +379,7 @@ public interface FlagService extends OpenmrsService {
 	 * @param displayPointId the DisplayPointId of the DisplayPoint to remove
 	 */
 	@Authorized( { PatientFlagsConstants.PRIV_MANAGE_FLAGS })
-	public void purgeDisplayPoint(Integer DisplayPointId);
+	public void purgeDisplayPoint(Integer displayPointId);
 	
 	/**
 	 * Returns the current Patient Flags properties in a PatientFlagsProperties object

--- a/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
@@ -13,13 +13,7 @@
  */
 package org.openmrs.module.patientflags.api.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
@@ -44,6 +38,14 @@ import org.openmrs.module.patientflags.comparator.TagAlphaComparator;
 import org.openmrs.module.patientflags.db.FlagDAO;
 import org.openmrs.module.patientflags.filter.Filter;
 import org.openmrs.module.patientflags.filter.FilterType;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Implementation of the {@link FlagService}
@@ -184,7 +186,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	}
 	
 	/**
-	 * @see org.openmrs.module.patientflags.api.FlagService#getFlagsByFilter()
+	 * @see org.openmrs.module.patientflags.api.FlagService#getFlagsByFilter(Filter)
 	 */
 	public List<Flag> getFlagsByFilter(Filter filter) {
 		// should we change this so the filtering happens in the DAO?
@@ -199,12 +201,26 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	}
 	
 	/**
-	 * @see org.openmrs.module.patientflags.api.FlagService#getFlag(Flag)
+	 * @see org.openmrs.module.patientflags.api.FlagService#getFlag(Integer)
 	 */
 	public Flag getFlag(Integer flagId) {
 		return dao.getFlag(flagId);
 	}
-	
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getFlagByUuid(String)
+	 */
+	public Flag getFlagByUuid(String uuid) {
+		return dao.getFlagByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getFlagByName(String)
+	 */
+	public Flag getFlagByName(String name) {
+		return dao.getFlagByName(name);
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#saveFlag(Flag)
 	 */
@@ -224,7 +240,17 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 		// then refresh the cache
 		refreshCache();
 	}
-	
+
+	public void retireFlag(Flag flag, String retiredReason) {
+		if (StringUtils.isNotBlank(retiredReason)) {
+			flag.setRetired(true);
+			flag.setRetireReason(retiredReason);
+			Context.getService(FlagService.class).saveFlag(flag);
+		} else {
+			throw new APIException("A reason is required when retiring a patient flag");
+		}
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#getAllTags()
 	 */
@@ -243,7 +269,21 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	public Tag getTag(Integer tagId) {
 		return dao.getTag(tagId);
 	}
-	
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getTagByUuid(String)
+	 */
+	public Tag getTagByUuid(String uuid) {
+		return dao.getTagByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getTagByName(String)
+	 */
+	public Tag getTagByName(String name) {
+		return dao.getTag(name);
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#getTag(String)
 	 */
@@ -268,7 +308,20 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 		// then refresh the cache
 		refreshCache();
 	}
-	
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#retireFlag(Flag, String)
+	 */
+	public void retireTag(Tag tag, String retiredReason) {
+		if (StringUtils.isNotBlank(retiredReason)) {
+			tag.setRetired(true);
+			tag.setRetireReason(retiredReason);
+			Context.getService(FlagService.class).saveTag(tag);
+		} else {
+			throw new APIException("A reason is required when retiring a tag for patient flags");
+		}
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#getAllPriorities()
 	 */
@@ -287,7 +340,21 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	public Priority getPriority(Integer priorityId) {
 		return dao.getPriority(priorityId);
 	}
-	
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getPriorityByUuid(String)
+	 */
+	public Priority getPriorityByUuid(String uuid) {
+		return dao.getPriorityByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getPriorityByName(String)
+	 */
+	public Priority getPriorityByName(String name) {
+		return dao.getPriorityByName(name);
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#savePriority(Priority)
 	 */
@@ -314,7 +381,21 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 		// remove the flag from the DB table
 		dao.purgePriority(priorityId);
 	}
-	
+
+	/**
+	 *
+	 * @see org.openmrs.module.patientflags.api.FlagService#retirePriority(Priority, String)
+	 */
+	public void retirePriority(Priority priority, String retiredReason) {
+		if (StringUtils.isNotBlank(retiredReason)) {
+			priority.setRetired(true);
+			priority.setRetireReason(retiredReason);
+			Context.getService(FlagService.class).savePriority(priority);
+		} else {
+			throw new APIException("A reason is required when retiring a priority for patient flags");
+		}
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#getAllDisplayPoints()
 	 */
@@ -328,7 +409,14 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	public DisplayPoint getDisplayPoint(Integer displayPointId) {
 		return dao.getDisplayPoint(displayPointId);
 	}
-	
+
+	/**
+	 * @see org.openmrs.module.patientflags.api.FlagService#getDisplayPointByUuid(String)
+	 */
+	public DisplayPoint getDisplayPointByUuid(String uuid) {
+		return null;
+	}
+
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#getDisplayPoint(String)
 	 */

--- a/api/src/main/java/org/openmrs/module/patientflags/db/FlagDAO.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/db/FlagDAO.java
@@ -50,6 +50,24 @@ public interface FlagDAO {
 	 * @throws DAOException
 	 */
 	public Flag getFlag(Integer flagId) throws DAOException;
+
+	/**
+	 * Gets a Flag from the Flag table by its uuid
+	 *
+	 * @param uuid the uuid of the flag to retrieve
+	 * @return the specified Flag
+	 * @throws DAOException
+	 */
+	public Flag getFlagByUuid(String uuid) throws DAOException;
+
+	/**
+	 * Gets a Flag from the Flag table by its name
+	 *
+	 * @param name the name of the flag to retrieve
+	 * @return the specified Flag
+	 * @throws DAOException
+	 */
+	public Flag getFlagByName(String name) throws DAOException;
 	
 	/**
 	 * Saves a Flag in the Flag table
@@ -92,6 +110,15 @@ public interface FlagDAO {
 	 * @throws DAOException
 	 */
 	public Tag getTag(String name) throws DAOException;
+
+	/**
+	 * Gets a Tag from the Tag table by its uuid
+	 *
+	 * @param uuid
+	 * @return the specified Tag
+	 * @throws DAOException
+	 */
+	public Tag getTagByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * Saves a Tag in the Tag table
@@ -125,6 +152,24 @@ public interface FlagDAO {
 	 * @throws DAOException
 	 */
 	public Priority getPriority(Integer priorityId) throws DAOException;
+
+	/**
+	 * Gets a Priority from the Priority table by its uuid
+	 *
+	 * @param uuid the uuid of the Priority to retrieve
+	 * @return the specified Priority
+	 * @throws DAOException
+	 */
+	public Priority getPriorityByUuid(String uuid) throws DAOException;
+
+	/**
+	 * Gets a Priority from the Priority table by its uuid
+	 *
+	 * @param name the name of the Priority to retrieve
+	 * @return the specified Priority
+	 * @throws DAOException
+	 */
+	public Priority getPriorityByName(String name) throws DAOException;
 	
 	/**
 	 * Saves a Priority in the Priority table

--- a/api/src/main/java/org/openmrs/module/patientflags/evaluator/SQLFlagEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/evaluator/SQLFlagEvaluator.java
@@ -133,8 +133,9 @@ public class SQLFlagEvaluator implements FlagEvaluator {
 		// if we've gotten this far, mark the criteria as valid
 		return new FlagValidationResult(true);
 	}
-
-	@Override
+	/**
+	 * @see org.openmrs.module.patientflags.evaluator.FlagEvaluator#evalMessage(Flag, int)
+	 */
 	public String evalMessage(Flag flag, int patientId) {
 		String literal = "\\$\\{\\d{1,2}\\}";
 		String message = flag.getMessage();

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/bundle/PatientFlagMetadataBundle.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/bundle/PatientFlagMetadataBundle.java
@@ -1,0 +1,73 @@
+package org.openmrs.module.patientflags.metadatadeploy.bundle;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Transformer;
+import org.apache.commons.lang.StringUtils;
+import org.openmrs.OpenmrsObject;
+import org.openmrs.Role;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
+import org.openmrs.module.patientflags.Flag;
+import org.openmrs.module.patientflags.Priority;
+import org.openmrs.module.patientflags.Tag;
+import org.openmrs.module.patientflags.metadatadeploy.descriptor.FlagDescriptor;
+import org.openmrs.module.patientflags.metadatadeploy.descriptor.PriorityDescriptor;
+import org.openmrs.module.patientflags.metadatadeploy.descriptor.TagDescriptor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class PatientFlagMetadataBundle extends AbstractMetadataBundle {
+
+    protected void install(TagDescriptor tagDescriptor) {
+        Tag tag = new Tag(tagDescriptor.name());
+        if (StringUtils.isNotBlank(tagDescriptor.uuid())) {
+            tag.setUuid(tagDescriptor.uuid());
+        }
+
+        if (CollectionUtils.isNotEmpty(tagDescriptor.roles())) {
+            tag.setRoles((Set)CollectionUtils.collect(tagDescriptor.roles(), new Transformer() {
+                public Object transform(Object o) {
+                    return MetadataUtils.existing(Role.class, (String)o);
+                }
+            }, new HashSet()));
+        }
+
+        this.install((OpenmrsObject) tag);
+    }
+
+    protected void install(PriorityDescriptor priorityDescriptor) {
+        Priority priority = new Priority(priorityDescriptor.name(), priorityDescriptor.style(), priorityDescriptor.rank());
+        if (StringUtils.isNotBlank(priorityDescriptor.description())) {
+            priority.setDescription(priorityDescriptor.description());
+        }
+        if (StringUtils.isNotBlank(priorityDescriptor.uuid())) {
+            priority.setUuid(priorityDescriptor.uuid());
+        }
+
+        this.install((OpenmrsObject) priority);
+    }
+
+    protected void install(FlagDescriptor flagDescriptor) {
+        Flag flag = new Flag(flagDescriptor.name(), flagDescriptor.criteria(), flagDescriptor.message());
+        if (StringUtils.isNotBlank(flagDescriptor.priority())) {
+            flag.setPriority(MetadataUtils.existing(Priority.class, (String) flagDescriptor.priority()));
+        }
+
+        flag.setEvaluator(flagDescriptor.evaluator());
+
+        if (StringUtils.isNotBlank(flagDescriptor.uuid())) {
+            flag.setUuid(flagDescriptor.uuid());
+        }
+
+        if (CollectionUtils.isNotEmpty(flagDescriptor.tags())) {
+            flag.setTags((Set)CollectionUtils.collect(flagDescriptor.tags(), new Transformer() {
+                public Object transform(Object o) {
+                    return MetadataUtils.existing(Tag.class, (String)o);
+                }
+            }, new HashSet()));
+        }
+
+        this.install((OpenmrsObject) flag);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/FlagDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/FlagDescriptor.java
@@ -1,0 +1,32 @@
+package org.openmrs.module.patientflags.metadatadeploy.descriptor;
+
+import org.openmrs.module.metadatadeploy.descriptor.MetadataDescriptor;
+import org.openmrs.module.patientflags.Flag;
+import org.openmrs.module.patientflags.Priority;
+import org.openmrs.module.patientflags.Tag;
+
+import java.util.List;
+import java.util.Set;
+
+public abstract class FlagDescriptor extends MetadataDescriptor<Flag> {
+
+    public Class<Flag> getDescribedType() {
+        return Flag.class;
+    }
+
+    public abstract String criteria();
+
+    public String evaluator() {
+            return"org.openmrs.module.patientflags.evaluator.SQLFlagEvaluator";
+    }
+
+    public abstract String message();
+
+    public abstract String priority();
+
+    public abstract List<String> tags();
+
+    public Boolean enabled() {
+        return Boolean.TRUE;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/PriorityDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/PriorityDescriptor.java
@@ -1,0 +1,15 @@
+package org.openmrs.module.patientflags.metadatadeploy.descriptor;
+
+import org.openmrs.module.metadatadeploy.descriptor.MetadataDescriptor;
+import org.openmrs.module.patientflags.Priority;
+
+public abstract class PriorityDescriptor extends MetadataDescriptor<Priority> {
+
+    public Class<Priority> getDescribedType() {
+        return Priority.class;
+    }
+
+    public abstract String style();
+
+    public abstract Integer rank();
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/TagDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/descriptor/TagDescriptor.java
@@ -1,0 +1,15 @@
+package org.openmrs.module.patientflags.metadatadeploy.descriptor;
+
+import org.openmrs.module.metadatadeploy.descriptor.MetadataDescriptor;
+import org.openmrs.module.patientflags.Tag;
+
+import java.util.List;
+
+public abstract class TagDescriptor extends MetadataDescriptor<Tag> {
+
+    public Class<Tag> getDescribedType() {
+        return Tag.class;
+    }
+
+    public abstract List<String> roles();
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/FlagDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/FlagDeployHandler.java
@@ -1,0 +1,33 @@
+package org.openmrs.module.patientflags.metadatadeploy.handler;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.metadatadeploy.handler.AbstractObjectDeployHandler;
+import org.openmrs.module.patientflags.Flag;
+import org.openmrs.module.patientflags.api.FlagService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Handler(supports = {Flag.class})
+public class FlagDeployHandler extends AbstractObjectDeployHandler<Flag> {
+
+    @Autowired
+    @Qualifier("flagService")
+    private FlagService flagService;
+
+    public Flag fetch(String identifier) {
+        return this.flagService.getFlagByUuid(identifier);
+    }
+
+    public Flag save(Flag flag) {
+        this.flagService.saveFlag(flag);
+        return flag;
+    }
+
+    public void uninstall(Flag flag, String reason) {
+        this.flagService.retireFlag(flag, reason);
+    }
+
+    public Flag findAlternateMatch(Flag incomingPriority) {
+        return this.flagService.getFlagByName(incomingPriority.getName());
+    }
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/PriorityDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/PriorityDeployHandler.java
@@ -1,0 +1,33 @@
+package org.openmrs.module.patientflags.metadatadeploy.handler;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.metadatadeploy.handler.AbstractObjectDeployHandler;
+import org.openmrs.module.patientflags.Priority;
+import org.openmrs.module.patientflags.api.FlagService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Handler(supports = {Priority.class})
+public class PriorityDeployHandler extends AbstractObjectDeployHandler<Priority> {
+
+    @Autowired
+    @Qualifier("flagService")
+    private FlagService flagService;
+
+    public Priority fetch(String identifier) {
+        return this.flagService.getPriorityByUuid(identifier);
+    }
+
+    public Priority save(Priority priority) {
+        this.flagService.savePriority(priority);
+        return priority;
+    }
+
+    public void uninstall(Priority priority, String reason) {
+        this.flagService.retirePriority(priority, reason);
+    }
+
+    public Priority findAlternateMatch(Priority incomingPriority) {
+        return this.flagService.getPriorityByName(incomingPriority.getName());
+    }
+}

--- a/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/TagDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/metadatadeploy/handler/TagDeployHandler.java
@@ -1,0 +1,33 @@
+package org.openmrs.module.patientflags.metadatadeploy.handler;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.metadatadeploy.handler.AbstractObjectDeployHandler;
+import org.openmrs.module.patientflags.Tag;
+import org.openmrs.module.patientflags.api.FlagService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Handler(supports = {Tag.class})
+public class TagDeployHandler extends AbstractObjectDeployHandler<Tag> {
+
+    @Autowired
+    @Qualifier("flagService")
+    private FlagService flagService;
+
+    public Tag fetch(String identifier) {
+        return this.flagService.getTagByUuid(identifier);
+    }
+
+    public Tag save(Tag tag) {
+        this.flagService.saveTag(tag);
+        return tag;
+    }
+
+    public void uninstall(Tag tag, String reason) {
+        this.flagService.retireTag(tag, reason);
+    }
+
+    public Tag findAlternateMatch(Tag incomingTag) {
+        return this.flagService.getTagByName(incomingTag.getName());
+    }
+}

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet id="patientflags-unique-flagname-20171115-1600" author="ssmusoke">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="patientflags_flag_name_unique"></indexExists>
+            </not>
+        </preConditions>
+        <comment>Add a unique constraint to the name of the flag</comment>
+        <addUniqueConstraint tableName="patientflags_flag" columnNames="name" constraintName="patientflags_flag_name_unique"></addUniqueConstraint>
+    </changeSet>
+
+    <changeSet id="patientflags-unique-priorityname-20171115-1600" author="ssmusoke">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="patientflags_priority_name_unique"></indexExists>
+            </not>
+        </preConditions>
+        <comment>Add a unique constraint to the name of the priority</comment>
+        <addUniqueConstraint tableName="patientflags_priority" columnNames="name"  constraintName="patientflags_priority_name_unique"></addUniqueConstraint>
+    </changeSet>
+
+    <changeSet id="patientflags-unique-tagname-20171115-1600" author="ssmusoke">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="patientflags_tag_name_unique"></indexExists>
+            </not>
+        </preConditions>
+        <comment>Add a unique constraint to the name of the tag</comment>
+        <addUniqueConstraint tableName="patientflags_tag" columnNames="name"  constraintName="patientflags_tag_name_unique"></addUniqueConstraint>
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -15,29 +15,32 @@
 	<context:component-scan base-package="@MODULE_PACKAGE@" />
 	
 	<!--  Configure the Flag Service -->
-   	<bean parent="serviceContext" id="flagService">
+	<!-- Service -->
+	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list>
 				<value>org.openmrs.module.patientflags.api.FlagService</value>
-				<bean class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
-					<property name="transactionManager"><ref bean="transactionManager"/></property>
-					<property name="target">
-						<bean class="org.openmrs.module.patientflags.api.impl.FlagServiceImpl">
-							<property name="flagDAO">
-								<bean class="org.openmrs.module.patientflags.db.hibernate.HibernateFlagDAO">
-									<property name="sessionFactory"><ref bean="dbSessionFactory"/></property>
-								</bean>
-							</property>
-						</bean>
-					</property>
-					<property name="preInterceptors">
-							<ref bean="serviceInterceptors"/>  <!--  handles common metadata fields -->
-					</property>
-					<property name="transactionAttributeSource">
-						<bean class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource"/>
-					</property>
-				</bean>
+				<ref local="flagService"/>
 			</list>
+		</property>
+	</bean>
+
+	<bean id="flagService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager"><ref bean="transactionManager"/></property>
+		<property name="target">
+			<bean class="org.openmrs.module.patientflags.api.impl.FlagServiceImpl">
+				<property name="flagDAO">
+					<bean class="org.openmrs.module.patientflags.db.hibernate.HibernateFlagDAO">
+						<property name="sessionFactory"><ref bean="dbSessionFactory"/></property>
+					</bean>
+				</property>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+				<ref bean="serviceInterceptors"/>  <!--  handles common metadata fields -->
+		</property>
+		<property name="transactionAttributeSource">
+			<bean class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource"/>
 		</property>
 	</bean>
 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -18,6 +18,7 @@
 
 	<require_modules>
 		<require_module version="${uiframeworkVersion}">org.openmrs.module.uiframework</require_module>
+		<require_module>org.openmrs.module.metadatadeploy</require_module>
 	</require_modules>
 
 	<!-- Aware of Modules-->

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,18 @@
 				<version>${uiframeworkVersion}</version>
 				<scope>provided</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>metadatadeploy-api</artifactId>
+				<version>${metadatadeployVersion}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>metadatasharing-api</artifactId>
+				<version>${metadatasharingVersion}</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -87,6 +99,8 @@
 		<openMRSMinorVersion>1.9</openMRSMinorVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<uiframeworkVersion>3.11.0</uiframeworkVersion>
+		<metadatadeployVersion>1.8.1</metadatadeployVersion>
+		<metadatasharingVersion>1.2.2</metadatasharingVersion>
 	</properties>
 
 	<build>


### PR DESCRIPTION
A summary of the changes is listed below to ease review:

1. Added dependency to metadata-deploy and metadata-sharing api modules 

2. config.xml - added required for metadata-deploy and metadata-sharing

3. Added descriptors and deploy handlers for Tag, Priority and Flags. I am not sure how to use DisplayPoint so left that out for now, pointers are welcome 

4. Updated the service and DAO to enable finding of tag, priority and flags by uuid and name 

5. Added a metadata bundle that deploys Tag, Priority and Flag descriptors this is what modules will extend to deploy their custom metadata 

6. moduleAppilcationContext.xml - cleaned up the definition of the flagService to match other modules 

see https://github.com/METS-Programme/openmrs-module-aijar/pull/317 for usage of the API for deploying patient flags 

https://issues.openmrs.org/browse/FLAG-27