### PR TITLE
FLAG-64:Add Actions Column Global property Label in the Flag Table

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -19,6 +19,7 @@ patientflags.tag=Tag
 patientflags.name=Name
 patientflags.status=Status
 patientflags.submit=Submit
+patientflags.actions=Actions
 patientflags.cancel=Cancel
 patientflags.filter=Filter
 patientflags.preview=Preview

--- a/omod/src/main/webapp/manageFlags.jsp
+++ b/omod/src/main/webapp/manageFlags.jsp
@@ -52,6 +52,7 @@
 		<th><spring:message code="patientflags.tags" /></th>
 		<th><spring:message code="patientflags.priority" /></th>
 		<th><spring:message code="patientflags.status" /></th>
+		<th><spring:message code="patientflags.actions" /></th>
 		<th>&nbsp;</th>
 	</tr>
 	<c:set var="i" value="0" />


### PR DESCRIPTION
https://issues.openmrs.org/browse/FLAG-64

Added an Actions Column in the flag Table
Before
![actions](https://user-images.githubusercontent.com/48015736/191445374-b3871fc8-6e9e-4c26-819c-0f13575eb279.png)
After
![coractions](https://user-images.githubusercontent.com/48015736/191445420-c93a4360-1f2f-4933-af9b-80447dd81ab7.png)
cc @dkayiwa 