### PR TITLE
FLAG-66: Fixing the MalformedInputException error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
 					<artifactId>maven-openmrs-plugin</artifactId>
 					<version>1.0.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.1</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/FLAG-66

When running mvn clean install, we get the following error.

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources (default-resources) on project patientflags-api: filtering /openmrs-module-patientflags/api/src/main/resources/messages_fr.properties to /openmrs-module-patientflags/api/target/classes/messages_fr.properties failed with MalformedInputException: Input length = 1 -`

To resolve this, adding maven-resources-plugin:3.0.1