### PR TITLE
FLAG-67: Fix rendering of flags via simple objects that is currently broken in platform version greater than 2.5.*

### DIFF
--- a/omod/src/main/java/org/openmrs/module/patientflags/fragment/controller/PatientflagsDashboardFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/patientflags/fragment/controller/PatientflagsDashboardFragmentController.java
@@ -50,7 +50,7 @@ public class PatientflagsDashboardFragmentController {
 
         SimpleObject simpleObject = new SimpleObject();
 
-        simpleObject.put("", flagsString);
+        simpleObject.put("patientflags", flagsString);
 
         return simpleObject;
     }

--- a/omod/src/main/webapp/fragments/patientflagsDashboard.gsp
+++ b/omod/src/main/webapp/fragments/patientflagsDashboard.gsp
@@ -14,7 +14,9 @@
             }, function (response) {
                 if (!response) {
                     ${ ui.message("coreapps.none ") }
-                } else {
+                } else if(response.substring(1,14)==="patientflags="){
+                    jq("#flags").html(response.replace("{patientflags=\"", "").replace("\"}", ""));
+                }else{
                     jq("#flags").html(response.patientflags);
                 }
             });

--- a/omod/src/main/webapp/fragments/patientflagsDashboard.gsp
+++ b/omod/src/main/webapp/fragments/patientflagsDashboard.gsp
@@ -15,7 +15,7 @@
                 if (!response) {
                     ${ ui.message("coreapps.none ") }
                 } else {
-                    jq("#flags").html(response.replace("{=", "").replace("}", ""));
+                    jq("#flags").html(response.patientflags);
                 }
             });
         </script>


### PR DESCRIPTION
# Description of what I changed 

1. I added a key for the patient flags object returned to the UI via a simple object in the PatientflagsDashboardFragmentController 

# Issues I worked on 

https://issues.openmrs.org/browse/FLAG-67

