### PR TITLE
FLAG-69: Evaluate patient flags in parallel

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientflags/task/PatientFlagTask.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/task/PatientFlagTask.java
@@ -27,15 +27,15 @@ import org.openmrs.module.patientflags.api.FlagService;
 public class PatientFlagTask implements Runnable {
 
 	private static DaemonToken daemonToken;
-	
+
 	private Patient patient;
-	
+
 	private Flag flag;
-	
+
 	@Override
 	public void run() {
 		FlagService flagService = Context.getService(FlagService.class);
-		
+
 		if (patient != null) {
 			generatePatientFlags(patient, flagService);
 		}
@@ -46,7 +46,7 @@ public class PatientFlagTask implements Runnable {
 			evaluateAllFlags();
 		}
 	}
-	
+
 	public static Runnable evaluateAllFlags() {
 		return Daemon.runInDaemonThread(new AllFlagsEvaluator(), daemonToken);
 	}
@@ -54,37 +54,37 @@ public class PatientFlagTask implements Runnable {
 	public static void setDaemonToken(DaemonToken token) {
 		daemonToken = token;
 	}
-	
+
 	public void generatePatientFlags(Patient patient) {
 		this.patient = patient;
-		
+
 		if (daemonToken != null) {
 			Daemon.runInDaemonThread(this, daemonToken);
 		}
 	}
-	
+
 	public void generatePatientFlags(Flag flag) {
 		this.flag = flag;
-		
+
 		if (daemonToken != null) {
 			Daemon.runInDaemonThread(this, daemonToken);
 		}
 	}
 
 	private static void generatePatientFlags(Flag flag, FlagService service) {
-		
+
 		service.deletePatientFlagsForFlag(flag);
-		
+
 		if (!flag.getEnabled() || flag.isRetired()) {
 			return;
 		}
-		
+
 		HashMap<Object, Object> context = new HashMap<Object, Object>();
 		org.openmrs.Cohort cohort = service.getFlaggedPatients(flag, context);
 		if (cohort == null) {
 			return;
 		}
-		
+
 		java.util.Set<Integer> members =  cohort.getMemberIds();
 		for (Integer patientId : members) {
 			List<String> flgs = (List<String>)context.get(patientId);
@@ -98,10 +98,10 @@ public class PatientFlagTask implements Runnable {
 			}
 		}
 	}
-	
+
 	private void generatePatientFlags(Patient patient, FlagService service) {
 		service.deletePatientFlagsForPatient(patient);
-		
+
 		HashMap<Object, Object> context = new HashMap<Object, Object>();
 		List<Flag> flags = service.generateFlagsForPatient(patient, context);
 		for (Flag flag : flags) {
@@ -116,7 +116,7 @@ public class PatientFlagTask implements Runnable {
 			}
 		}
 	}
-	
+
 	//The only reason why we have this class is to be able to run in
 	//a daemon thread in order to get daemon access to the database
 	private static class AllFlagsEvaluator implements Runnable {
@@ -124,7 +124,7 @@ public class PatientFlagTask implements Runnable {
 		@Override
 		public void run() {
 			FlagService flagService = Context.getService(FlagService.class);
-			
+
 			for (Flag flag : flagService.getAllFlags()) {
 				generatePatientFlags(flag, flagService);
 			}


### PR DESCRIPTION
## Description of what I change

change to evaluate patient flags in parallely on generateFlagsForPatient(...) method.

## Issue Worked On

worked on [FLAG-69](https://openmrs.atlassian.net/browse/FLAG-69)

[FLAG-69]: https://openmrs.atlassian.net/browse/FLAG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test
 use the method execution time in milliseconds (ms) to evaluate the performance.
**Generate flags for patient**

current module 
flags count < 5
current module perform better than this implementations
flags count < 10
both are perform in same way
flags count = 17
this implementation perform better than current module

**when the flag count is increased, the prell process performs better than the current module.**

**All flag evaluation**

current module for 17 flags -> 203, 202, 205 ,216, 185, 215
This implementation for 17 flags -> 37, 38, 22 ,23, 20 ,27,26 ,32 