### PR TITLE
FLAG-69: Improve the performance of patient flag evaluation

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
@@ -105,7 +105,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 
 		executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 		// test each Flag in the cache against the specific Patient
-		for (final Flag flag : filter.filter(flagCache)) {
+		filter.filter(flagCache).forEach(flag -> {
 			// trap bad flags so that they don't hang the system
 			executor.submit(() -> {
 				try {
@@ -121,7 +121,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 					Context.closeSession();
 				}
 			});
-		}
+		});
 
 		executor.shutdown();
 		try {

--- a/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
@@ -708,6 +708,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	@Override
 	public Future<?> evaluateAllFlags() {
 		executor = Executors.newSingleThreadExecutor();
+
 		return executor.submit(PatientFlagTask.evaluateAllFlags());
 	}
 	

--- a/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -95,23 +96,41 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 	/**
 	 * @see org.openmrs.module.patientflags.api.FlagService#generateFlagsForPatient(Patient, Filter, Map<Object, Object>)
 	 */
-	public List<Flag> generateFlagsForPatient(Patient patient, Filter filter, Map<Object, Object> context) {
-		List<Flag> results = new ArrayList<Flag>();
-		
+	public List<Flag> generateFlagsForPatient(final Patient patient, Filter filter, final Map<Object, Object> context) {
+		final List<Flag> results = new ArrayList<Flag>();
+
 		// we can get rid of this once onStartup is implemented
 		if (!isInitialized)
 			refreshCache();
-		
+
+		executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 		// test each Flag in the cache against the specific Patient
-		for (Flag flag : filter.filter(flagCache)) {
+		for (final Flag flag : filter.filter(flagCache)) {
 			// trap bad flags so that they don't hang the system
-			try {
-				if (flag.eval(patient, context))
-					results.add(flag);
+			executor.submit(() -> {
+				try {
+					Context.openSession();
+					if (flag.eval(patient, context)) {
+						synchronized (results) {
+							results.add(flag);
+						}
+					}
+				} catch (Exception e) {
+					log.error("Unable to test flag " + flag.getName() + " on patient #" + patient.getId(), e);
+				} finally {
+					Context.closeSession();
+				}
+			});
+		}
+
+		executor.shutdown();
+		try {
+			if (!executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.NANOSECONDS)) {
+				log.error("Executor service did not terminate");
 			}
-			catch (Exception e) {
-				log.error("Unable to test flag " + flag.getName() + " on patient #" + patient.getId(), e);
-			}
+		} catch (InterruptedException e) {
+			log.error("Thread pool was interrupted while waiting for flag evaluation tasks to complete", e);
+			Thread.currentThread().interrupt();
 		}
 		return results;
 	}
@@ -688,10 +707,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 
 	@Override
 	public Future<?> evaluateAllFlags() {
-		if (executor == null) {
-			executor = Executors.newSingleThreadExecutor();
-		}
-		
+		executor = Executors.newSingleThreadExecutor();
 		return executor.submit(PatientFlagTask.evaluateAllFlags());
 	}
 	


### PR DESCRIPTION
### Description of what I change
change to evaluate patient flags in parallely on generateFlagsForPatient(...) method.

### Issue Worked On
worked on [FLAG-69](https://openmrs.atlassian.net/browse/FLAG-69)

### Test
use the method execution time in milliseconds (ms) to evaluate the performance.
Generate flags for patient

Generate flags for patient
parallel process -> 7.6.5.8,7,7,6,7,8,6 => avg 6.7 milliseconds

current module -> 8,7,7,6,8,7,7,7,8,6 => avg 7.1 milliseconds
 
flags count < 5 - current module perform better than this implementations
flags count < 10 - both are perform in same way
flags count = 17 - this implementation perform better than current module

**when the flag count is increased, the prell process performs better than the current module.**


[FLAG-69]: https://openmrs.atlassian.net/browse/FLAG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

method test : generate flags for patient :[ FalgServiceImpl.generateFlagsForPatient(Patient patient, Context)](https://github.com/openmrs/openmrs-module-patientflags/blob/8223e7f35adedbcac7ee2ea657fc74e092a2b803/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java#L97)