### PR TITLE
FLAG-69:  Improve the performance of the evaluating all flags

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientflags/api/impl/FlagServiceImpl.java
@@ -700,10 +700,7 @@ public class FlagServiceImpl extends BaseOpenmrsService implements FlagService {
 
 	@Override
 	public Future<?> evaluateAllFlags() {
-		if (executor == null) {
-			executor = Executors.newSingleThreadExecutor();
-		}
-		
+		executor = Executors.newSingleThreadExecutor();
 		return executor.submit(PatientFlagTask.evaluateAllFlags());
 	}
 	


### PR DESCRIPTION
### Description of what I change
 refactor evaluate all flags to process in parallel. 

### Issue Worked On
worked on [FLAG-69](https://openmrs.atlassian.net/browse/FLAG-69)

### Test
Evaluate all flags 10 times
parallel process -> 74, 58 , 63 . 47 , 79, 40 , 101, 121 , 58 => avg 64.1 milliseconds

current module -> 258, 230, 215, 208, 207, 208, 204, 196,202, 198 => avg 212.6 milliseconds

evaluate all flags :[ PatientFlagTask.AllFlagsEvaluator](https://github.com/openmrs/openmrs-module-patientflags/blob/8223e7f35adedbcac7ee2ea657fc74e092a2b803/api/src/main/java/org/openmrs/module/patientflags/task/PatientFlagTask.java#L122)


[FLAG-69]: https://openmrs.atlassian.net/browse/FLAG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ